### PR TITLE
支持是活雷锋和都是活雷锋的检查

### DIFF
--- a/src/dongbei.py
+++ b/src/dongbei.py
@@ -654,6 +654,13 @@ class ComparisonExpr(Expr):
   def ToPython(self):
     if self.relation.value == KW_IS_NONE:
       return f'({self.op1.ToPython()}) is None'
+    elif self.relation.value == KW_IS_VAR:
+      if isinstance(self.op1, VariableExpr):
+        return f'"{self.op1.var}" in locals()'
+      else:
+        return 'False'
+    elif self.relation.value == KW_IS_LIST:
+      return f'isinstance({self.op1.ToPython()}, list)'
     return '%s %s %s' % (self.op1.ToPython(),
                          COMPARISON_KEYWORD_TO_PYTHON[self.relation.value],
                          self.op2.ToPython())
@@ -1384,6 +1391,14 @@ class DongbeiParser(object):
     cmp = self.TryConsumeKeyword(KW_IS_NONE)
     if cmp:
       return ComparisonExpr(arith, Keyword(KW_IS_NONE), None)
+
+    cmp = self.TryConsumeKeyword(KW_IS_VAR)
+    if cmp:
+      return ComparisonExpr(arith, Keyword(KW_IS_VAR), None)
+
+    cmp = self.TryConsumeKeyword(KW_IS_LIST)
+    if cmp:
+      return ComparisonExpr(arith, Keyword(KW_IS_LIST), None)
 
     return arith
 


### PR DESCRIPTION
自然语言是支持歧义的，我觉得可以考虑引入这种歧义的表达。

```
老王是活雷锋。
唠唠：老王。               # 啥也不是
唠唠：老王啥也不是。 # 没毛病
唠唠：老王是活雷锋。 # 没毛病
老王装二。
唠唠：老王是活雷锋。 # 没毛病
唠唠：二是活雷锋。     # 有毛病

老王们都是活雷锋。
唠唠：老王们都是活雷锋。 # 没毛病
老王们来了个老王。
唠唠：老王们都是活雷锋。 # 没毛病
```
